### PR TITLE
Feature/enhance logging layout

### DIFF
--- a/src/main/java/io/slifer/automation/logs/Layout.java
+++ b/src/main/java/io/slifer/automation/logs/Layout.java
@@ -3,6 +3,7 @@ package io.slifer.automation.logs;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.LayoutBase;
+import io.slifer.automation.config.RunContext;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -18,7 +19,9 @@ public class Layout extends LayoutBase<ILoggingEvent> {
     public String doLayout(ILoggingEvent event) {
         StringBuffer buffer = new StringBuffer();
         buffer.append(new SimpleDateFormat("HH:mm:ss:SSS").format(new Date()));
-        // buffer.append("|" + AutomatedTest.testName() + "|"); TODO uncomment when test configuration is in place
+        buffer.append("|");
+        buffer.append(RunContext.getTestCaseName());
+        buffer.append("|");
         buffer.append(event.getLoggerName());
         buffer.append("|");
         buffer.append(event.getLevel());


### PR DESCRIPTION
Restored logging layout to original design which will include the test case name in the entries. This will be more easy to read than a thread ID and when exported, will give a key of sorts from which the logs can be sorted and viewed.