### PR TITLE
Fix/logging cleanup

### DIFF
--- a/src/main/java/io/slifer/automation/commands/Commands.java
+++ b/src/main/java/io/slifer/automation/commands/Commands.java
@@ -24,7 +24,7 @@ public abstract class Commands {
         boolean hasFailures = false;
         
         for (Condition condition : conditions) {
-            LOG.info("Asserting Condition -> {}", condition.description());
+            LOG.info("Asserting Condition :: {}", condition.description());
             try {
                 boolean result = condition.result();
                 Assert.assertTrue(result);

--- a/src/main/java/io/slifer/automation/commands/WebDriverCommands.java
+++ b/src/main/java/io/slifer/automation/commands/WebDriverCommands.java
@@ -192,7 +192,7 @@ public abstract class WebDriverCommands extends Commands {
      * @param condition The Condition to be satisfied during the wait.
      */
     public void pause(Condition condition) {
-        LOG.info("Wait for condition -> {}", condition.description());
+        LOG.info("Wait for condition :: {}", condition.description());
         WebDriverWait webDriverWait = new WebDriverWait(RunContext.getWebDriver(), RunContext.timeout);
         
         try {


### PR DESCRIPTION
Adjusted log output for tests for the following:
- Showing input values in `enterTExt()` calls
- Showing options to be selected in `select()` calls
- Cleanup of validation and wait logging by replacing `->` with `::` in logs when evaluating conditions