### PR TITLE
Dynamic Logging Level

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -14,7 +14,7 @@
         </encoder>
     </appender>
     
-    <root level="debug">
+    <root level="${logLevel:-INFO}">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="TestNG"/>
     </root>


### PR DESCRIPTION
Default logging level is now definable via command line option. `-DloggingLevel=INFO`

If the argument is not given, INFO is used by default.