### PR TITLE
Fix/send keys

### DIFF
--- a/src/main/java/io/slifer/automation/commands/WebCommander.java
+++ b/src/main/java/io/slifer/automation/commands/WebCommander.java
@@ -363,7 +363,7 @@ public class WebCommander extends Commands {
                 builder.append(charSequence);
             }
             else if (charSequence instanceof Keys) {
-                builder.append(((Keys) charSequence).name());
+                builder.append(((Keys) charSequence).name() + "-key");
             }
             separator = ", ";
         }


### PR DESCRIPTION
The `enterText()` method accepts a `CharSequence...` argument, which allows both String and `Keys` input to be sent. Logging of this input was always an array, even if a single String of text was being sent (as is done in a vast majority of cases), resulting in output with double-braces, such as `[[input]]`. Additionally, when `Keys` enumerations are sent, the logs will show unrecognized symbols, completely obfuscating the input.

This change adds some processing of the input value and builds a String that is sent to the logs with String input segments, and identifiers for `Keys` input, as comma separated values.

The only drawback of this fix is, it does not yet support the output of `Keys.chord()`. Since `chord()` returns a String, we still get unrecognized symbols in the logs. Some extra time will need to be spent refining the logic that parses the input so it can detect `chord()` output. In the meantime, though, I'm ok letting this through since `chord()` is such a seldomly used feature in my experience.