### PR TITLE
Feature/browser options

### DIFF
--- a/src/main/java/io/slifer/automation/config/CapabilityProvider.java
+++ b/src/main/java/io/slifer/automation/config/CapabilityProvider.java
@@ -69,7 +69,7 @@ public class CapabilityProvider {
         return capabilities;
     }
     
-    public static List<String> loadOptions(Browser browser) {
+    private static List<String> loadOptions(Browser browser) {
         List<String> options = new ArrayList<>();
         String fileName = "config/" + browser.name().toLowerCase() + ".args";
         


### PR DESCRIPTION
Adding the capability to pass custom arguments to Chrome and Firefox via resource file.

Within `src/test/resources/config`, files called `chrome.args` and `firefox.args` will be detected and loaded, allowing a user to pass custom configuration arguments to the WebDriver. Any standard argument that would otherwise be passed to the `addArguments()` method need only be added to the appropriate args file with one argument per line.

If the file is not detected, or otherwise is unable to be loaded, no arguments will be passed to the WebDriver. If an exception is caught during the loading process, though, the logs will contain information helpful for troubleshooting.

Edge and Internet Explorer have been omitted from this change for the time being. Initial development of this library is done using Selenium 3.151.59 as the base. Numerous updates to browser options classes have been since added, including to Edge, that will be present in the 4.0 series of Selenium. 