### PR TITLE
Fix/pom dev info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     
     <groupId>io.qadenz</groupId>
     <artifactId>qadenz</artifactId>
-    <version>1.0.0-BETA-1</version>
+    <version>1.0.0-BETA-1.1</version>
     
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
Hotfix to correct the missing `<developers>` node on the pom.xml. This prevented successful publishing to Maven Central.