### PR TITLE
Fix/boolean visibility

### DIFF
--- a/src/main/java/io/qadenz/automation/reporter/Screenshot.java
+++ b/src/main/java/io/qadenz/automation/reporter/Screenshot.java
@@ -35,7 +35,7 @@ public class Screenshot {
     /**
      * A convenience boolean to pass to {@code check()} or {@code verify()} to enhance readability of the code.
      */
-    private static final boolean SKIP = false;
+    public static final boolean SKIP = false;
     
     public void capture() {
         String uuid = UUID.randomUUID().toString();


### PR DESCRIPTION
Fixing the `Screenshot.SKIP` boolean visibility. It was set to private and needed to be public.