### PR TITLE
93 upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,19 +42,19 @@
         <commons-lang.version>3.12.0</commons-lang.version>
         <hamcrest.version>2.2</hamcrest.version>
         <imgscalr.version>4.2</imgscalr.version>
-        <jackson.version>2.12.5</jackson.version>
-        <json.version>20210307</json.version>
-        <jsoup.version>1.14.2</jsoup.version>
-        <logback.version>1.2.6</logback.version>
+        <jackson.version>2.13.0</jackson.version>
+        <json.version>20211205</json.version>
+        <jsoup.version>1.14.3</jsoup.version>
+        <logback.version>1.2.7</logback.version>
         <logback-contrib.version>0.1.5</logback-contrib.version>
         <logback-testng.version>1.3.4</logback-testng.version>
         <selenium.version>4.1.0</selenium.version>
         <sizzle.version>4.0.0-R1</sizzle.version>
         <testng.version>7.4.0</testng.version>
         
-        <byte-buddy.version>1.11.18</byte-buddy.version>
-        <junit.version>5.8.1</junit.version>
-        <mockito.version>3.12.4</mockito.version>
+        <byte-buddy.version>1.12.3</byte-buddy.version>
+        <junit.version>5.8.2</junit.version>
+        <mockito.version>4.1.0</mockito.version>
     </properties>
     
     <dependencies>


### PR DESCRIPTION
jackson-databind to 2.12.5
json to 20211205
jsoup to 1.14.3
logback-classic to 1.2.7
selenium-java to 4.1.0
byte-buddy to 1.12.3
junit-jupiter-api to 5.8.2
mockito-junit-jupiter to 4.1.0