### PR TITLE
91 update visibility check

### DIFF
--- a/src/main/java/dev/qadenz/automation/commands/WebInspector.java
+++ b/src/main/java/dev/qadenz/automation/commands/WebInspector.java
@@ -378,7 +378,7 @@ public class WebInspector {
                 }
     
                 if (visible) {
-                    visible = (!webElements.get(0).getAttribute("hidden").equalsIgnoreCase("true"));
+                    visible = (webElements.get(0).getAttribute("hidden") == null);
                     LOG.debug("Checked for attribute 'hidden' - Visibility is [{}].", visible);
                 }
                 


### PR DESCRIPTION
Dropped the old `ng-hide` check in the `getVisibilityOfElement()` method. I decided to make one addition, however. Since we were removing `ng-hide` due to it being part of Angular, and the idea of not making any assumptions about a UI under test, I decided to take a quick look at the W3C spec and see what other means of hiding elements were supported. I found and added a check for the `hidden` attribute. This results in Qadenz supporting W3C defined means of hiding elements, and the JSON config is available to users to need to add any additional checks.