### PR TITLE
Updated dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,29 +39,29 @@
         <java.version>11</java.version>
         
         <commons-io.version>2.11.0</commons-io.version>
-        <commons-lang.version>3.12.0</commons-lang.version>
+        <commons-lang3.version>3.12.0</commons-lang3.version>
         <hamcrest.version>2.2</hamcrest.version>
-        <imgscalr.version>4.2</imgscalr.version>
-        <jackson.version>2.13.0</jackson.version>
-        <json.version>20211205</json.version>
-        <jsoup.version>1.14.3</jsoup.version>
-        <logback.version>1.2.7</logback.version>
+        <imgscalr-lib.version>4.2</imgscalr-lib.version>
+        <jackson-databind.version>2.13.4</jackson-databind.version>
+        <json.version>20220924</json.version>
+        <jsoup.version>1.15.3</jsoup.version>
+        <logback-classic.version>1.4.3</logback-classic.version>
         <logback-contrib.version>0.1.5</logback-contrib.version>
-        <logback-testng.version>1.3.4</logback-testng.version>
-        <selenium.version>4.2.0</selenium.version>
+        <logback-testng.version>2.0.0</logback-testng.version>
+        <selenium.version>4.5.0</selenium.version>
         <sizzle.version>2.3.4</sizzle.version>
-        <testng.version>7.6.0</testng.version>
+        <testng.version>7.6.1</testng.version>
         
-        <byte-buddy.version>1.12.3</byte-buddy.version>
-        <junit.version>5.8.2</junit.version>
-        <mockito.version>4.1.0</mockito.version>
+        <byte-buddy.version>1.12.17</byte-buddy.version>
+        <junit-jupiter-api.version>5.9.1</junit-jupiter-api.version>
+        <mockito-junit-jupiter.version>4.8.0</mockito-junit-jupiter.version>
     </properties>
     
     <dependencies>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${logback-classic.version}</version>
         </dependency>
         
         <dependency>
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson-databind.version}</version>
         </dependency>
         
         <dependency>
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang.version}</version>
+            <version>${commons-lang3.version}</version>
         </dependency>
         
         <dependency>
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>org.imgscalr</groupId>
             <artifactId>imgscalr-lib</artifactId>
-            <version>${imgscalr.version}</version>
+            <version>${imgscalr-lib.version}</version>
         </dependency>
         
         <dependency>
@@ -159,14 +159,14 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.version}</version>
+            <version>${junit-jupiter-api.version}</version>
             <scope>test</scope>
         </dependency>
         
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>${mockito.version}</version>
+            <version>${mockito-junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Updating all dependencies to recent versions. 

Selenium now running at version 4.5.0. This does skip some versions, but that's on me for falling behind on maintenance.