### PR TITLE
Upgraded dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,19 +42,19 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <hamcrest.version>2.2</hamcrest.version>
         <imgscalr-lib.version>4.2</imgscalr-lib.version>
-        <jackson-databind.version>2.13.4</jackson-databind.version>
+        <jackson-databind.version>2.14.2</jackson-databind.version>
         <json.version>20220924</json.version>
         <jsoup.version>1.15.3</jsoup.version>
-        <logback-classic.version>1.4.3</logback-classic.version>
+        <logback-classic.version>1.4.5</logback-classic.version>
         <logback-contrib.version>0.1.5</logback-contrib.version>
         <logback-testng.version>2.0.0</logback-testng.version>
-        <selenium.version>4.5.0</selenium.version>
+        <selenium.version>4.8.0</selenium.version>
         <sizzle.version>2.3.4</sizzle.version>
-        <testng.version>7.6.1</testng.version>
+        <testng.version>7.7.1</testng.version>
         
-        <byte-buddy.version>1.12.17</byte-buddy.version>
-        <junit-jupiter-api.version>5.9.1</junit-jupiter-api.version>
-        <mockito-junit-jupiter.version>4.8.0</mockito-junit-jupiter.version>
+        <byte-buddy.version>1.12.22</byte-buddy.version>
+        <junit-jupiter-api.version>5.9.2</junit-jupiter-api.version>
+        <mockito-junit-jupiter.version>5.0.0</mockito-junit-jupiter.version>
     </properties>
     
     <dependencies>
@@ -176,7 +176,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.10.1</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -186,7 +186,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -200,7 +200,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -215,7 +215,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.0.0-M8</version>
                 <configuration>
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>


### PR DESCRIPTION
Updating to the latest of dependencies and maven plugins.

Selenium is now at 4.8.0, which skips several versions since last release. I will be more diligent on keeping this one up to date going forward.