### PR TITLE
132 date expectation logging output is not formatted properly

### DIFF
--- a/src/main/java/dev/qadenz/automation/conditions/DirectTextOfElementAsDate.java
+++ b/src/main/java/dev/qadenz/automation/conditions/DirectTextOfElementAsDate.java
@@ -25,15 +25,17 @@ public class DirectTextOfElementAsDate implements Condition {
     
     private Locator locator;
     private DateTimeFormatter dateTimeFormatter;
-    private Expectation<LocalDate> expectation;
+    private TemporalExpectation<LocalDate> expectation;
     
     private LocalDate elementDate;
     
     public DirectTextOfElementAsDate(Locator locator, DateTimeFormatter dateTimeFormatter,
-            Expectation<LocalDate> expectation) {
+            TemporalExpectation<LocalDate> expectation) {
         this.locator = locator;
         this.dateTimeFormatter = dateTimeFormatter;
         this.expectation = expectation;
+        
+        this.expectation.setDateTimeFormatter(dateTimeFormatter);
     }
     
     @Override

--- a/src/main/java/dev/qadenz/automation/conditions/DirectTextOfElementAsDateTime.java
+++ b/src/main/java/dev/qadenz/automation/conditions/DirectTextOfElementAsDateTime.java
@@ -25,15 +25,17 @@ public class DirectTextOfElementAsDateTime implements Condition {
     
     private Locator locator;
     private DateTimeFormatter dateTimeFormatter;
-    private Expectation<LocalDateTime> expectation;
+    private TemporalExpectation<LocalDateTime> expectation;
     
     private LocalDateTime elementDateTime;
     
     public DirectTextOfElementAsDateTime(Locator locator, DateTimeFormatter dateTimeFormatter,
-            Expectation<LocalDateTime> expectation) {
+            TemporalExpectation<LocalDateTime> expectation) {
         this.locator = locator;
         this.dateTimeFormatter = dateTimeFormatter;
         this.expectation = expectation;
+        
+        this.expectation.setDateTimeFormatter(dateTimeFormatter);
     }
     
     @Override

--- a/src/main/java/dev/qadenz/automation/conditions/DirectTextOfElementAsTime.java
+++ b/src/main/java/dev/qadenz/automation/conditions/DirectTextOfElementAsTime.java
@@ -25,15 +25,17 @@ public class DirectTextOfElementAsTime implements Condition {
     
     private Locator locator;
     private DateTimeFormatter dateTimeFormatter;
-    private Expectation<LocalTime> expectation;
+    private TemporalExpectation<LocalTime> expectation;
     
     private LocalTime elementTime;
     
     public DirectTextOfElementAsTime(Locator locator, DateTimeFormatter dateTimeFormatter,
-            Expectation<LocalTime> expectation) {
+            TemporalExpectation<LocalTime> expectation) {
         this.locator = locator;
         this.dateTimeFormatter = dateTimeFormatter;
         this.expectation = expectation;
+        
+        this.expectation.setDateTimeFormatter(dateTimeFormatter);
     }
     
     @Override

--- a/src/main/java/dev/qadenz/automation/conditions/TemporalExpectation.java
+++ b/src/main/java/dev/qadenz/automation/conditions/TemporalExpectation.java
@@ -1,0 +1,22 @@
+/*
+Copyright 2021 Tim Slifer
+
+Licensed under the PolyForm Internal Use License, Version 1.0.0 (the "License");
+you may not use this file except in compliance with the License.
+A copy of the License may be obtained at
+
+https://polyformproject.org/licenses/internal-use/1.0.0/
+ */
+package dev.qadenz.automation.conditions;
+
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Interface modeling an expectation used for evaluating Date/Time-based Conditions.
+ *
+ * @author Tim Slifer
+ */
+public interface TemporalExpectation<T> extends Expectation<T> {
+    
+    void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter);
+}

--- a/src/main/java/dev/qadenz/automation/conditions/TextOfElementAsDate.java
+++ b/src/main/java/dev/qadenz/automation/conditions/TextOfElementAsDate.java
@@ -24,15 +24,17 @@ public class TextOfElementAsDate implements Condition {
     
     private Locator locator;
     private DateTimeFormatter dateTimeFormatter;
-    private Expectation<LocalDate> expectation;
+    private TemporalExpectation<LocalDate> expectation;
     
     private LocalDate elementDate;
     
     public TextOfElementAsDate(Locator locator, DateTimeFormatter dateTimeFormatter,
-            Expectation<LocalDate> expectation) {
+            TemporalExpectation<LocalDate> expectation) {
         this.locator = locator;
         this.dateTimeFormatter = dateTimeFormatter;
         this.expectation = expectation;
+        
+        this.expectation.setDateTimeFormatter(dateTimeFormatter);
     }
     
     @Override

--- a/src/main/java/dev/qadenz/automation/conditions/TextOfElementAsDateTime.java
+++ b/src/main/java/dev/qadenz/automation/conditions/TextOfElementAsDateTime.java
@@ -24,15 +24,17 @@ public class TextOfElementAsDateTime implements Condition {
     
     private Locator locator;
     private DateTimeFormatter dateTimeFormatter;
-    private Expectation<LocalDateTime> expectation;
+    private TemporalExpectation<LocalDateTime> expectation;
     
     private LocalDateTime elementDateTime;
     
     public TextOfElementAsDateTime(Locator locator, DateTimeFormatter dateTimeFormatter,
-            Expectation<LocalDateTime> expectation) {
+            TemporalExpectation<LocalDateTime> expectation) {
         this.locator = locator;
         this.dateTimeFormatter = dateTimeFormatter;
         this.expectation = expectation;
+        
+        this.expectation.setDateTimeFormatter(dateTimeFormatter);
     }
     
     @Override

--- a/src/main/java/dev/qadenz/automation/conditions/TextOfElementAsTime.java
+++ b/src/main/java/dev/qadenz/automation/conditions/TextOfElementAsTime.java
@@ -24,15 +24,17 @@ public class TextOfElementAsTime implements Condition {
     
     private Locator locator;
     private DateTimeFormatter dateTimeFormatter;
-    private Expectation<LocalTime> expectation;
+    private TemporalExpectation<LocalTime> expectation;
     
     private LocalTime elementTime;
     
     public TextOfElementAsTime(Locator locator, DateTimeFormatter dateTimeFormatter,
-            Expectation<LocalTime> expectation) {
+            TemporalExpectation<LocalTime> expectation) {
         this.locator = locator;
         this.dateTimeFormatter = dateTimeFormatter;
         this.expectation = expectation;
+        
+        this.expectation.setDateTimeFormatter(dateTimeFormatter);
     }
     
     @Override

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsAfter.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsAfter.java
@@ -9,20 +9,22 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdate;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalDateMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 /**
  * An expectation for the text of an element, represented as a LocalDate, to be after the given LocalDate.
  *
  * @author Tim Slifer
  */
-public class LocalDateIsAfter implements Expectation<LocalDate> {
+public class LocalDateIsAfter implements TemporalExpectation<LocalDate> {
     
     private LocalDate localDate;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateIsAfter(LocalDate localDate) {
         this.localDate = localDate;
@@ -35,6 +37,11 @@ public class LocalDateIsAfter implements Expectation<LocalDate> {
     
     @Override
     public String description() {
-        return "is after [" + localDate.toString() + "]";
+        return "is after [" + localDate.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsBefore.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsBefore.java
@@ -9,20 +9,22 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdate;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalDateMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 /**
  * An expectation for the text of an element, represented as a LocalDate, to be before the given LocalDate.
  *
  * @author Tim Slifer
  */
-public class LocalDateIsBefore implements Expectation<LocalDate> {
+public class LocalDateIsBefore implements TemporalExpectation<LocalDate> {
     
     private LocalDate localDate;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateIsBefore(LocalDate localDate) {
         this.localDate = localDate;
@@ -35,6 +37,11 @@ public class LocalDateIsBefore implements Expectation<LocalDate> {
     
     @Override
     public String description() {
-        return "is before [" + localDate.toString() + "]";
+        return "is before [" + localDate.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsDayOfWeek.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsDayOfWeek.java
@@ -9,12 +9,13 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdate;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalDateMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.util.Locale;
 
@@ -23,9 +24,10 @@ import java.util.Locale;
  *
  * @author Tim Slifer
  */
-public class LocalDateIsDayOfWeek implements Expectation<LocalDate> {
+public class LocalDateIsDayOfWeek implements TemporalExpectation<LocalDate> {
     
     private DayOfWeek dayOfWeek;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateIsDayOfWeek(DayOfWeek dayOfWeek) {
         this.dayOfWeek = dayOfWeek;
@@ -39,5 +41,10 @@ public class LocalDateIsDayOfWeek implements Expectation<LocalDate> {
     @Override
     public String description() {
         return "is day of week [" + dayOfWeek.getDisplayName(TextStyle.FULL, Locale.ENGLISH) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsDayOfWeek.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsDayOfWeek.java
@@ -9,13 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdate;
 
-import dev.qadenz.automation.conditions.TemporalExpectation;
+import dev.qadenz.automation.conditions.Expectation;
 import org.exparity.hamcrest.date.LocalDateMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.util.Locale;
 
@@ -24,10 +23,9 @@ import java.util.Locale;
  *
  * @author Tim Slifer
  */
-public class LocalDateIsDayOfWeek implements TemporalExpectation<LocalDate> {
+public class LocalDateIsDayOfWeek implements Expectation<LocalDate> {
     
     private DayOfWeek dayOfWeek;
-    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateIsDayOfWeek(DayOfWeek dayOfWeek) {
         this.dayOfWeek = dayOfWeek;
@@ -41,10 +39,5 @@ public class LocalDateIsDayOfWeek implements TemporalExpectation<LocalDate> {
     @Override
     public String description() {
         return "is day of week [" + dayOfWeek.getDisplayName(TextStyle.FULL, Locale.ENGLISH) + "]";
-    }
-    
-    @Override
-    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
-        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsNotDayOfWeek.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsNotDayOfWeek.java
@@ -9,13 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdate;
 
-import dev.qadenz.automation.conditions.TemporalExpectation;
+import dev.qadenz.automation.conditions.Expectation;
 import org.exparity.hamcrest.date.LocalDateMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.util.Locale;
 
@@ -26,10 +25,9 @@ import static org.hamcrest.Matchers.not;
  *
  * @author Tim Slifer
  */
-public class LocalDateIsNotDayOfWeek implements TemporalExpectation<LocalDate> {
+public class LocalDateIsNotDayOfWeek implements Expectation<LocalDate> {
     
     private DayOfWeek dayOfWeek;
-    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateIsNotDayOfWeek(DayOfWeek dayOfWeek) {
         this.dayOfWeek = dayOfWeek;
@@ -43,10 +41,5 @@ public class LocalDateIsNotDayOfWeek implements TemporalExpectation<LocalDate> {
     @Override
     public String description() {
         return "is not day of week [" + dayOfWeek.getDisplayName(TextStyle.FULL, Locale.ENGLISH) + "]";
-    }
-    
-    @Override
-    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
-        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsNotDayOfWeek.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsNotDayOfWeek.java
@@ -9,12 +9,13 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdate;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalDateMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.util.Locale;
 
@@ -25,9 +26,10 @@ import static org.hamcrest.Matchers.not;
  *
  * @author Tim Slifer
  */
-public class LocalDateIsNotDayOfWeek implements Expectation<LocalDate> {
+public class LocalDateIsNotDayOfWeek implements TemporalExpectation<LocalDate> {
     
     private DayOfWeek dayOfWeek;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateIsNotDayOfWeek(DayOfWeek dayOfWeek) {
         this.dayOfWeek = dayOfWeek;
@@ -41,5 +43,10 @@ public class LocalDateIsNotDayOfWeek implements Expectation<LocalDate> {
     @Override
     public String description() {
         return "is not day of week [" + dayOfWeek.getDisplayName(TextStyle.FULL, Locale.ENGLISH) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsNotSameAs.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsNotSameAs.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdate;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalDateMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 import static org.hamcrest.Matchers.not;
 
@@ -22,9 +23,10 @@ import static org.hamcrest.Matchers.not;
  *
  * @author Tim Slifer
  */
-public class LocalDateIsNotSameAs implements Expectation<LocalDate> {
+public class LocalDateIsNotSameAs implements TemporalExpectation<LocalDate> {
     
     private LocalDate localDate;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateIsNotSameAs(LocalDate localDate) {
         this.localDate = localDate;
@@ -37,6 +39,11 @@ public class LocalDateIsNotSameAs implements Expectation<LocalDate> {
     
     @Override
     public String description() {
-        return "is the same as [" + localDate.toString() + "]";
+        return "is the same as [" + localDate.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsNotWithin.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsNotWithin.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdate;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalDateMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 
 import static org.hamcrest.Matchers.not;
@@ -24,11 +25,12 @@ import static org.hamcrest.Matchers.not;
  *
  * @author Tim Slifer
  */
-public class LocalDateIsNotWithin implements Expectation<LocalDate> {
+public class LocalDateIsNotWithin implements TemporalExpectation<LocalDate> {
     
     private Long period;
     private ChronoUnit chronoUnit;
     private LocalDate localDate;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateIsNotWithin(Long period, ChronoUnit chronoUnit, LocalDate localDate) {
         this.period = period;
@@ -43,6 +45,12 @@ public class LocalDateIsNotWithin implements Expectation<LocalDate> {
     
     @Override
     public String description() {
-        return "is not within [" + period + " " + chronoUnit.toString() + "] of [" + localDate.toString() + "]";
+        return "is not within [" + period + " " + chronoUnit.toString() + "] of [" +
+                localDate.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsSameAs.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsSameAs.java
@@ -9,20 +9,22 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdate;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalDateMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 /**
  * An expectation for the text of an element, represented as a LocalDate, to be the same as the given LocalDate.
  *
  * @author Tim Slifer
  */
-public class LocalDateIsSameAs implements Expectation<LocalDate> {
+public class LocalDateIsSameAs implements TemporalExpectation<LocalDate> {
     
     private LocalDate localDate;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateIsSameAs(LocalDate localDate) {
         this.localDate = localDate;
@@ -35,6 +37,11 @@ public class LocalDateIsSameAs implements Expectation<LocalDate> {
     
     @Override
     public String description() {
-        return "is the same as [" + localDate.toString() + "]";
+        return "is the same as [" + localDate.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsSameAsOrAfter.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsSameAsOrAfter.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdate;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalDateMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 /**
  * An expectation for the text of an element, represented as a LocalDate, to be the same as or after the given
@@ -21,9 +22,10 @@ import java.time.LocalDate;
  *
  * @author Tim Slifer
  */
-public class LocalDateIsSameAsOrAfter implements Expectation<LocalDate> {
+public class LocalDateIsSameAsOrAfter implements TemporalExpectation<LocalDate> {
     
     private LocalDate localDate;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateIsSameAsOrAfter(LocalDate localDate) {
         this.localDate = localDate;
@@ -36,6 +38,11 @@ public class LocalDateIsSameAsOrAfter implements Expectation<LocalDate> {
     
     @Override
     public String description() {
-        return "is the same as or after [" + localDate.toString() + "]";
+        return "is the same as or after [" + localDate.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsSameAsOrBefore.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsSameAsOrBefore.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdate;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalDateMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 /**
  * An expectation for the text of an element, represented as a LocalDate, to be the same as or before the given
@@ -21,9 +22,10 @@ import java.time.LocalDate;
  *
  * @author Tim Slifer
  */
-public class LocalDateIsSameAsOrBefore implements Expectation<LocalDate> {
+public class LocalDateIsSameAsOrBefore implements TemporalExpectation<LocalDate> {
     
     private LocalDate localDate;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateIsSameAsOrBefore(LocalDate localDate) {
         this.localDate = localDate;
@@ -36,6 +38,11 @@ public class LocalDateIsSameAsOrBefore implements Expectation<LocalDate> {
     
     @Override
     public String description() {
-        return "is the same as or before [" + localDate.toString() + "]";
+        return "is the same as or before [" + localDate.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsWithin.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdate/LocalDateIsWithin.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdate;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalDateMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 
 /**
@@ -22,11 +23,12 @@ import java.time.temporal.ChronoUnit;
  *
  * @author Tim Slifer
  */
-public class LocalDateIsWithin implements Expectation<LocalDate> {
+public class LocalDateIsWithin implements TemporalExpectation<LocalDate> {
     
     private Long period;
     private ChronoUnit chronoUnit;
     private LocalDate localDate;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateIsWithin(Long period, ChronoUnit chronoUnit, LocalDate localDate) {
         this.period = period;
@@ -41,6 +43,12 @@ public class LocalDateIsWithin implements Expectation<LocalDate> {
     
     @Override
     public String description() {
-        return "is within [" + period + " " + chronoUnit.toString() + "] of [" + localDate.toString() + "]";
+        return "is within [" + period + " " + chronoUnit.toString() + "] of [" +
+                localDate.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdatetime/LocalDateTimeIsAfter.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdatetime/LocalDateTimeIsAfter.java
@@ -9,20 +9,22 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdatetime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalDateTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * An expectation for the text of an element, represented as a LocalDateTime, to be after the given LocalDateTime.
  *
  * @author Tim Slifer
  */
-public class LocalDateTimeIsAfter implements Expectation<LocalDateTime> {
+public class LocalDateTimeIsAfter implements TemporalExpectation<LocalDateTime> {
     
     private LocalDateTime localDateTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateTimeIsAfter(LocalDateTime localDateTime) {
         this.localDateTime = localDateTime;
@@ -35,6 +37,11 @@ public class LocalDateTimeIsAfter implements Expectation<LocalDateTime> {
     
     @Override
     public String description() {
-        return "is after [" + localDateTime.toString() + "]";
+        return "is after [" + localDateTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdatetime/LocalDateTimeIsBefore.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdatetime/LocalDateTimeIsBefore.java
@@ -9,20 +9,22 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdatetime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalDateTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * An expectation for the text of an element, represented as a LocalDateTime, to be before the given LocalDateTime.
  *
  * @author Tim Slifer
  */
-public class LocalDateTimeIsBefore implements Expectation<LocalDateTime> {
+public class LocalDateTimeIsBefore implements TemporalExpectation<LocalDateTime> {
     
     private LocalDateTime localDateTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateTimeIsBefore(LocalDateTime localDateTime) {
         this.localDateTime = localDateTime;
@@ -35,6 +37,11 @@ public class LocalDateTimeIsBefore implements Expectation<LocalDateTime> {
     
     @Override
     public String description() {
-        return "is before [" + localDateTime.toString() + "]";
+        return "is before [" + localDateTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdatetime/LocalDateTimeIsNotSameAs.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdatetime/LocalDateTimeIsNotSameAs.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdatetime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalDateTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import static org.hamcrest.Matchers.not;
 
@@ -23,9 +24,10 @@ import static org.hamcrest.Matchers.not;
  *
  * @author Tim Slifer
  */
-public class LocalDateTimeIsNotSameAs implements Expectation<LocalDateTime> {
+public class LocalDateTimeIsNotSameAs implements TemporalExpectation<LocalDateTime> {
     
     private LocalDateTime localDateTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateTimeIsNotSameAs(LocalDateTime localDateTime) {
         this.localDateTime = localDateTime;
@@ -38,6 +40,11 @@ public class LocalDateTimeIsNotSameAs implements Expectation<LocalDateTime> {
     
     @Override
     public String description() {
-        return "is the same as [" + localDateTime.toString() + "]";
+        return "is the same as [" + localDateTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdatetime/LocalDateTimeIsNotWithin.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdatetime/LocalDateTimeIsNotWithin.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdatetime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalDateTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 
 import static org.hamcrest.Matchers.not;
@@ -24,11 +25,12 @@ import static org.hamcrest.Matchers.not;
  *
  * @author Tim Slifer
  */
-public class LocalDateTimeIsNotWithin implements Expectation<LocalDateTime> {
+public class LocalDateTimeIsNotWithin implements TemporalExpectation<LocalDateTime> {
     
     private Long period;
     private ChronoUnit chronoUnit;
     private LocalDateTime localDateTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateTimeIsNotWithin(Long period, ChronoUnit chronoUnit, LocalDateTime localDateTime) {
         this.period = period;
@@ -43,6 +45,12 @@ public class LocalDateTimeIsNotWithin implements Expectation<LocalDateTime> {
     
     @Override
     public String description() {
-        return "is not within [" + period + " " + chronoUnit.toString() + "] of [" + localDateTime.toString() + "]";
+        return "is not within [" + period + " " + chronoUnit.toString() + "] of [" +
+                localDateTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdatetime/LocalDateTimeIsSameAs.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdatetime/LocalDateTimeIsSameAs.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdatetime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalDateTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * An expectation for the text of an element, represented as a LocalDateTime, to be the same as the given
@@ -21,9 +22,10 @@ import java.time.LocalDateTime;
  *
  * @author Tim Slifer
  */
-public class LocalDateTimeIsSameAs implements Expectation<LocalDateTime> {
+public class LocalDateTimeIsSameAs implements TemporalExpectation<LocalDateTime> {
     
     private LocalDateTime localDateTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateTimeIsSameAs(LocalDateTime localDateTime) {
         this.localDateTime = localDateTime;
@@ -36,6 +38,11 @@ public class LocalDateTimeIsSameAs implements Expectation<LocalDateTime> {
     
     @Override
     public String description() {
-        return "is the same as [" + localDateTime.toString() + "]";
+        return "is the same as [" + localDateTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdatetime/LocalDateTimeIsSameAsOrAfter.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdatetime/LocalDateTimeIsSameAsOrAfter.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdatetime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalDateTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * An expectation for the text of an element, represented as a LocalDateTime, to be the same as or after the given
@@ -21,9 +22,10 @@ import java.time.LocalDateTime;
  *
  * @author Tim Slifer
  */
-public class LocalDateTimeIsSameAsOrAfter implements Expectation<LocalDateTime> {
+public class LocalDateTimeIsSameAsOrAfter implements TemporalExpectation<LocalDateTime> {
     
     private LocalDateTime localDateTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateTimeIsSameAsOrAfter(LocalDateTime localDateTime) {
         this.localDateTime = localDateTime;
@@ -36,6 +38,11 @@ public class LocalDateTimeIsSameAsOrAfter implements Expectation<LocalDateTime> 
     
     @Override
     public String description() {
-        return "is the same as or after [" + localDateTime.toString() + "]";
+        return "is the same as or after [" + localDateTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdatetime/LocalDateTimeIsSameAsOrBefore.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdatetime/LocalDateTimeIsSameAsOrBefore.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdatetime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalDateTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * An expectation for the text of an element, represented as a LocalDateTime, to be the same as or before the given
@@ -21,9 +22,10 @@ import java.time.LocalDateTime;
  *
  * @author Tim Slifer
  */
-public class LocalDateTimeIsSameAsOrBefore implements Expectation<LocalDateTime> {
+public class LocalDateTimeIsSameAsOrBefore implements TemporalExpectation<LocalDateTime> {
     
     private LocalDateTime localDateTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateTimeIsSameAsOrBefore(LocalDateTime localDateTime) {
         this.localDateTime = localDateTime;
@@ -36,6 +38,11 @@ public class LocalDateTimeIsSameAsOrBefore implements Expectation<LocalDateTime>
     
     @Override
     public String description() {
-        return "is the same as or before [" + localDateTime.toString() + "]";
+        return "is the same as or before [" + localDateTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdatetime/LocalDateTimeIsWithin.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localdatetime/LocalDateTimeIsWithin.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localdatetime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalDateTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 
 /**
@@ -22,11 +23,12 @@ import java.time.temporal.ChronoUnit;
  *
  * @author Tim Slifer
  */
-public class LocalDateTimeIsWithin implements Expectation<LocalDateTime> {
+public class LocalDateTimeIsWithin implements TemporalExpectation<LocalDateTime> {
     
     private Long period;
     private ChronoUnit chronoUnit;
     private LocalDateTime localDateTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalDateTimeIsWithin(Long period, ChronoUnit chronoUnit, LocalDateTime localDateTime) {
         this.period = period;
@@ -41,6 +43,12 @@ public class LocalDateTimeIsWithin implements Expectation<LocalDateTime> {
     
     @Override
     public String description() {
-        return "is within [" + period + " " + chronoUnit.toString() + "] of [" + localDateTime.toString() + "]";
+        return "is within [" + period + " " + chronoUnit.toString() + "] of [" +
+                localDateTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsAfter.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsAfter.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localtime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * An expectation for the text of an element, represented as a LocalDateTime, to be the same as or after the given
@@ -21,9 +22,10 @@ import java.time.LocalTime;
  *
  * @author Tim Slifer
  */
-public class LocalTimeIsAfter implements Expectation<LocalTime> {
+public class LocalTimeIsAfter implements TemporalExpectation<LocalTime> {
     
     private LocalTime localTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalTimeIsAfter(LocalTime localTime) {
         this.localTime = localTime;
@@ -36,6 +38,11 @@ public class LocalTimeIsAfter implements Expectation<LocalTime> {
     
     @Override
     public String description() {
-        return "is after [" + localTime.toString() + "]";
+        return "is after [" + localTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsBefore.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsBefore.java
@@ -9,20 +9,22 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localtime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * An expectation for the text of an element, represented as a LocalTime, to be before the given LocalTime.
  *
  * @author Tim Slifer
  */
-public class LocalTimeIsBefore implements Expectation<LocalTime> {
+public class LocalTimeIsBefore implements TemporalExpectation<LocalTime> {
     
     private LocalTime localTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalTimeIsBefore(LocalTime localTime) {
         this.localTime = localTime;
@@ -35,6 +37,11 @@ public class LocalTimeIsBefore implements Expectation<LocalTime> {
     
     @Override
     public String description() {
-        return "is before [" + localTime.toString() + "]";
+        return "is before [" + localTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsNotSameHourOfDay.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsNotSameHourOfDay.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localtime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 import static org.hamcrest.Matchers.not;
 
@@ -23,9 +24,10 @@ import static org.hamcrest.Matchers.not;
  *
  * @author Tim Slifer
  */
-public class LocalTimeIsNotSameHourOfDay implements Expectation<LocalTime> {
+public class LocalTimeIsNotSameHourOfDay implements TemporalExpectation<LocalTime> {
     
     private LocalTime localTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalTimeIsNotSameHourOfDay(LocalTime localTime) {
         this.localTime = localTime;
@@ -38,6 +40,11 @@ public class LocalTimeIsNotSameHourOfDay implements Expectation<LocalTime> {
     
     @Override
     public String description() {
-        return "is not same hour as [" + localTime.toString() + "]";
+        return "is not same hour as [" + localTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsNotSameMinuteOfHour.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsNotSameMinuteOfHour.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localtime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 import static org.hamcrest.Matchers.not;
 
@@ -23,9 +24,10 @@ import static org.hamcrest.Matchers.not;
  *
  * @author Tim Slifer
  */
-public class LocalTimeIsNotSameMinuteOfHour implements Expectation<LocalTime> {
+public class LocalTimeIsNotSameMinuteOfHour implements TemporalExpectation<LocalTime> {
     
     private LocalTime localTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalTimeIsNotSameMinuteOfHour(LocalTime localTime) {
         this.localTime = localTime;
@@ -38,6 +40,11 @@ public class LocalTimeIsNotSameMinuteOfHour implements Expectation<LocalTime> {
     
     @Override
     public String description() {
-        return "is not same minute as [" + localTime.toString() + "]";
+        return "is not same minute as [" + localTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsNotSameSecondOfMinute.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsNotSameSecondOfMinute.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localtime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 import static org.hamcrest.Matchers.not;
 
@@ -23,9 +24,10 @@ import static org.hamcrest.Matchers.not;
  *
  * @author Tim Slifer
  */
-public class LocalTimeIsNotSameSecondOfMinute implements Expectation<LocalTime> {
+public class LocalTimeIsNotSameSecondOfMinute implements TemporalExpectation<LocalTime> {
     
     private LocalTime localTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalTimeIsNotSameSecondOfMinute(LocalTime localTime) {
         this.localTime = localTime;
@@ -38,6 +40,11 @@ public class LocalTimeIsNotSameSecondOfMinute implements Expectation<LocalTime> 
     
     @Override
     public String description() {
-        return "is not same second as [" + localTime.toString() + "]";
+        return "is not same second as [" + localTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsNotWithin.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsNotWithin.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localtime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 
 import static org.hamcrest.Matchers.not;
@@ -24,11 +25,12 @@ import static org.hamcrest.Matchers.not;
  *
  * @author Tim Slifer
  */
-public class LocalTimeIsNotWithin implements Expectation<LocalTime> {
+public class LocalTimeIsNotWithin implements TemporalExpectation<LocalTime> {
     
     private Long period;
     private ChronoUnit chronoUnit;
     private LocalTime localTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalTimeIsNotWithin(Long period, ChronoUnit chronoUnit, LocalTime localTime) {
         this.period = period;
@@ -43,6 +45,12 @@ public class LocalTimeIsNotWithin implements Expectation<LocalTime> {
     
     @Override
     public String description() {
-        return "is not within [" + period + " " + chronoUnit.toString() + "] of [" + localTime.toString() + "]";
+        return "is not within [" + period + " " + chronoUnit.toString() + "] of [" +
+                localTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsSameAsOrAfter.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsSameAsOrAfter.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localtime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * An expectation for the text of an element, represented as a LocalTime, to be the same as or after the given
@@ -21,9 +22,10 @@ import java.time.LocalTime;
  *
  * @author Tim Slifer
  */
-public class LocalTimeIsSameAsOrAfter implements Expectation<LocalTime> {
+public class LocalTimeIsSameAsOrAfter implements TemporalExpectation<LocalTime> {
     
     private LocalTime localTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalTimeIsSameAsOrAfter(LocalTime localTime) {
         this.localTime = localTime;
@@ -36,6 +38,11 @@ public class LocalTimeIsSameAsOrAfter implements Expectation<LocalTime> {
     
     @Override
     public String description() {
-        return "is the same as or after [" + localTime.toString() + "]";
+        return "is the same as or after [" + localTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsSameAsOrBefore.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsSameAsOrBefore.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localtime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * An expectation for the text of an element, represented as a LocalTime, to be the same as or before the given
@@ -21,9 +22,10 @@ import java.time.LocalTime;
  *
  * @author Tim Slifer
  */
-public class LocalTimeIsSameAsOrBefore implements Expectation<LocalTime> {
+public class LocalTimeIsSameAsOrBefore implements TemporalExpectation<LocalTime> {
     
     private LocalTime localTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalTimeIsSameAsOrBefore(LocalTime localTime) {
         this.localTime = localTime;
@@ -36,6 +38,11 @@ public class LocalTimeIsSameAsOrBefore implements Expectation<LocalTime> {
     
     @Override
     public String description() {
-        return "is the same as or before [" + localTime.toString() + "]";
+        return "is the same as or before [" + localTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsSameHourOfDay.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsSameHourOfDay.java
@@ -9,20 +9,22 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localtime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * An expectation for the text of an element, represented as a LocalTime, to be the same hour as the given LocalTime.
  *
  * @author Tim Slifer
  */
-public class LocalTimeIsSameHourOfDay implements Expectation<LocalTime> {
+public class LocalTimeIsSameHourOfDay implements TemporalExpectation<LocalTime> {
     
     private LocalTime localTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalTimeIsSameHourOfDay(LocalTime localTime) {
         this.localTime = localTime;
@@ -35,6 +37,11 @@ public class LocalTimeIsSameHourOfDay implements Expectation<LocalTime> {
     
     @Override
     public String description() {
-        return "is same hour as [" + localTime.toString() + "]";
+        return "is same hour as [" + localTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsSameMinuteOfHour.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsSameMinuteOfHour.java
@@ -9,20 +9,22 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localtime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * An expectation for the text of an element, represented as a LocalTime, to be the same minute as the given LocalTime.
  *
  * @author Tim Slifer
  */
-public class LocalTimeIsSameMinuteOfHour implements Expectation<LocalTime> {
+public class LocalTimeIsSameMinuteOfHour implements TemporalExpectation<LocalTime> {
     
     private LocalTime localTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalTimeIsSameMinuteOfHour(LocalTime localTime) {
         this.localTime = localTime;
@@ -35,6 +37,11 @@ public class LocalTimeIsSameMinuteOfHour implements Expectation<LocalTime> {
     
     @Override
     public String description() {
-        return "is same minute as [" + localTime.toString() + "]";
+        return "is same minute as [" + localTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsSameSecondOfMinute.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsSameSecondOfMinute.java
@@ -9,20 +9,22 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localtime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * An expectation for the text of an element, represented as a LocalTime, to be the same second as the given LocalTime.
  *
  * @author Tim Slifer
  */
-public class LocalTimeIsSameSecondOfMinute implements Expectation<LocalTime> {
+public class LocalTimeIsSameSecondOfMinute implements TemporalExpectation<LocalTime> {
     
     private LocalTime localTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalTimeIsSameSecondOfMinute(LocalTime localTime) {
         this.localTime = localTime;
@@ -35,6 +37,11 @@ public class LocalTimeIsSameSecondOfMinute implements Expectation<LocalTime> {
     
     @Override
     public String description() {
-        return "is same second as [" + localTime.toString() + "]";
+        return "is same second as [" + localTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }

--- a/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsWithin.java
+++ b/src/main/java/dev/qadenz/automation/conditions/expectations/temporal/localtime/LocalTimeIsWithin.java
@@ -9,11 +9,12 @@ https://polyformproject.org/licenses/internal-use/1.0.0/
  */
 package dev.qadenz.automation.conditions.expectations.temporal.localtime;
 
-import dev.qadenz.automation.conditions.Expectation;
+import dev.qadenz.automation.conditions.TemporalExpectation;
 import org.exparity.hamcrest.date.LocalTimeMatchers;
 import org.hamcrest.Matcher;
 
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 
 /**
@@ -22,11 +23,12 @@ import java.time.temporal.ChronoUnit;
  *
  * @author Tim Slifer
  */
-public class LocalTimeIsWithin implements Expectation<LocalTime> {
+public class LocalTimeIsWithin implements TemporalExpectation<LocalTime> {
     
     private Long period;
     private ChronoUnit chronoUnit;
     private LocalTime localTime;
+    private DateTimeFormatter dateTimeFormatter;
     
     public LocalTimeIsWithin(Long period, ChronoUnit chronoUnit, LocalTime localTime) {
         this.period = period;
@@ -41,6 +43,12 @@ public class LocalTimeIsWithin implements Expectation<LocalTime> {
     
     @Override
     public String description() {
-        return "is within [" + period + " " + chronoUnit.toString() + "] of [" + localTime.toString() + "]";
+        return "is within [" + period + " " + chronoUnit.toString() + "] of [" +
+                localTime.format(dateTimeFormatter) + "]";
+    }
+    
+    @Override
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
     }
 }


### PR DESCRIPTION
The solution in place is a new Interface called `TemporalExpectation<T>` that extends `Expectation<T>`. This simply adds a setter that enables the Condition to pass the DateTimeFormatter to the Expectation for clear logging.

