### PR TITLE
Updated dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,56 +37,37 @@
     
     <properties>
         <java.version>11</java.version>
-        
-        <commons-io.version>2.11.0</commons-io.version>
-        <commons-lang3.version>3.12.0</commons-lang3.version>
-        <hamcrest-core.version>2.2</hamcrest-core.version>
-        <hamcrest-date.version>2.0.8</hamcrest-date.version>
-        <imgscalr-lib.version>4.2</imgscalr-lib.version>
-        <jackson-databind.version>2.14.2</jackson-databind.version>
-        <json.version>20230227</json.version>
-        <jsoup.version>1.15.4</jsoup.version>
-        <logback-classic.version>1.4.7</logback-classic.version>
-        <logback-contrib.version>0.1.5</logback-contrib.version>
-        <logback-testng.version>2.0.0</logback-testng.version>
-        <selenium.version>4.9.0</selenium.version>
-        <sizzle.version>2.3.4</sizzle.version>
-        <testng.version>7.7.1</testng.version>
-        
-        <byte-buddy.version>1.14.4</byte-buddy.version>
-        <junit-jupiter-api.version>5.9.2</junit-jupiter-api.version>
-        <mockito-junit-jupiter.version>5.3.1</mockito-junit-jupiter.version>
     </properties>
     
     <dependencies>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback-classic.version}</version>
+            <version>1.4.7</version>
         </dependency>
         
         <dependency>
             <groupId>ch.qos.logback.contrib</groupId>
             <artifactId>logback-json-classic</artifactId>
-            <version>${logback-contrib.version}</version>
+            <version>0.1.5</version>
         </dependency>
         
         <dependency>
             <groupId>ch.qos.logback.contrib</groupId>
             <artifactId>logback-jackson</artifactId>
-            <version>${logback-contrib.version}</version>
+            <version>0.1.5</version>
         </dependency>
         
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind.version}</version>
+            <version>2.15.2</version>
         </dependency>
         
         <dependency>
             <groupId>com.github.sbabcoc</groupId>
             <artifactId>logback-testng</artifactId>
-            <version>${logback-testng.version}</version>
+            <version>2.0.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -98,82 +79,82 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>${commons-io.version}</version>
+            <version>2.12.0</version>
         </dependency>
         
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
+            <version>3.12.0</version>
         </dependency>
         
         <dependency>
             <groupId>org.exparity</groupId>
             <artifactId>hamcrest-date</artifactId>
-            <version>${hamcrest-date.version}</version>
+            <version>2.0.8</version>
         </dependency>
         
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>${hamcrest-core.version}</version>
+            <version>2.2</version>
         </dependency>
         
         <dependency>
             <groupId>org.imgscalr</groupId>
             <artifactId>imgscalr-lib</artifactId>
-            <version>${imgscalr-lib.version}</version>
+            <version>4.2</version>
         </dependency>
         
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>${json.version}</version>
+            <version>20230227</version>
         </dependency>
         
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>${jsoup.version}</version>
+            <version>1.16.1</version>
         </dependency>
         
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>${selenium.version}</version>
+            <version>4.9.1</version>
         </dependency>
         
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>${testng.version}</version>
+            <version>7.8.0</version>
         </dependency>
         
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>sizzle</artifactId>
-            <version>${sizzle.version}</version>
+            <version>2.3.4</version>
         </dependency>
         
         <!--Test Dependencies -->
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>${byte-buddy.version}</version>
+            <version>1.14.5</version>
             <scope>test</scope>
         </dependency>
         
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit-jupiter-api.version}</version>
+            <version>5.9.3</version>
             <scope>test</scope>
         </dependency>
         
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>${mockito-junit-jupiter.version}</version>
+            <version>5.3.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -183,7 +164,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -193,7 +174,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -207,7 +188,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -222,7 +203,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M8</version>
+                <version>3.1.0</version>
                 <configuration>
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>


### PR DESCRIPTION
Notably, Selenium to 4.9.1. All other dependencies and maven plugins upgraded to latest versions.

Also, I nerfed the version properties on the pom.xml. It was much easier during the upgrade process to just have the version identifiers directly in line with the `<dependency>` entries.