### PR TITLE
144 maximize browser by default conflicts with configured window size

### DIFF
--- a/src/main/java/dev/qadenz/automation/config/AutomatedWebTest.java
+++ b/src/main/java/dev/qadenz/automation/config/AutomatedWebTest.java
@@ -117,7 +117,6 @@ public class AutomatedWebTest {
             throw exception;
         }
         
-        WebDriverProvider.getWebDriver().manage().window().maximize();
         WebDriverProvider.getWebDriver().get(WebConfig.appUrl);
     }
     


### PR DESCRIPTION
Maximizing the browser window is now performed via browser config json (if chrome) or invocation of webdriver maximize method.