### PR TITLE
Dependency upgrades, revisited

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
+            <artifactId>hamcrest-core</artifactId>
             <version>2.2</version>
         </dependency>
         


### PR DESCRIPTION
Rolling back to `hamcrest-core`. This is due to a change from `hamcrest-core` at version 2.2 to `hamcrest` at version 2.2 that removed the functionality of Substring matcher classes to be configured to ignore case. 

I will undoubtedly address this, but for now, what's here is and has been working well. With nearly 5 years since the last Hamcrest release, I believe there is little reason to rush.