### PR TITLE
Added css to log-entry lines to wrap and preserve white space

### DIFF
--- a/src/main/resources/html/report.css
+++ b/src/main/resources/html/report.css
@@ -1,5 +1,5 @@
 html {
-    font-family: 'Source Sans Pro', sans-serif !important;
+    font-family: "Source Sans Pro", sans-serif !important;
     background-color: #ffffff;
 }
 
@@ -118,6 +118,8 @@ html {
 
 .log-entry {
     width: 1155px;
+    word-wrap: break-word;
+    white-space: pre-wrap;
 }
 
 .screenshot {


### PR DESCRIPTION
It's a quick fix until a larger overhaul can be done on the HTML report, but this should clean up long URLs from spilling out.