### PR TITLE
125 report line wrapping

### DIFF
--- a/src/main/resources/html/report.css
+++ b/src/main/resources/html/report.css
@@ -119,7 +119,6 @@ html {
 .log-entry {
     width: 1155px;
     word-wrap: break-word;
-    white-space: pre-wrap;
 }
 
 .screenshot {


### PR DESCRIPTION
Reverting part of the previous changes. the `white-space: pre-wrap;` made the report layout pretty angry. The `word-wrap` worked a treat though.