### PR TITLE
179 fix screenshot logs

### DIFF
--- a/src/main/java/dev/qadenz/automation/reporter/JsonReporter.java
+++ b/src/main/java/dev/qadenz/automation/reporter/JsonReporter.java
@@ -227,8 +227,13 @@ public class JsonReporter {
     
     private List<String> siftAndTrim(List<String> input) {
         List<String> output = new ArrayList<>();
-        input.forEach(s -> output.addAll(Arrays.asList(s.split("\n"))));
-        // Yes, the reporter layout could be changed to accommodate this, but the console output will not be wrapped.
+        input.forEach(item -> {
+            // Yes, the reporter layout could be changed to accommodate this,
+            // but the console output will not be wrapped.
+            if (item.isEmpty()) {
+                output.add(item.trim());
+            }
+        });
         
         return output;
     }


### PR DESCRIPTION
Resolved issue of UUIDs being included in the logs. I didn't do a great job of proofreading Copilot's suggestion on this one and the logic changed pretty drastically. This corrects that problem while keeping the conversion in place from a for loop to invoking `.forEach()`.